### PR TITLE
[CONFIG] [Github Actions] sonarcloud deprecation replacement. https:/…

### DIFF
--- a/.github/workflows/python-coverage.yml
+++ b/.github/workflows/python-coverage.yml
@@ -61,8 +61,8 @@ jobs:
         run: |
           python3 -m coverage xml
 
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
+      - name: Analyze with SonarQube / SonarCloud
+        uses: SonarSource/sonarqube-scan-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           # Needed to get PR information, if any


### PR DESCRIPTION
…/github.com/SonarSource/sonarqube-scan-action

Warning

This action is deprecated and will be removed in a future release. Please use the sonarqube-scan-action action instead. The sonarqube-scan-action is a drop-in replacement for this action.